### PR TITLE
allow setting the superuser password from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN bzcat /opt/murmur-static_x86-${version}.tar.bz2 | tar -x -C /opt -f - && \
 
 # Copy in our slightly tweaked INI which points to our volume
 COPY murmur.ini /etc/murmur.ini
+COPY entrypoint.sh /entrypoint.sh
 
 # Forward apporpriate ports
 EXPOSE 64738/tcp 64738/udp
@@ -19,5 +20,5 @@ EXPOSE 64738/tcp 64738/udp
 VOLUME ["/data"]
 
 # Run murmur
-ENTRYPOINT ["/opt/murmur/murmur.x86", "-fg", "-v"]
+ENTRYPOINT "/entrypoint.sh"
 CMD ["-ini", "/etc/murmur.ini"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh 
+
+if [ "$SUPERUSER_PASSWORD" ]; then
+	/opt/murmur/murmur.x86 -supw $SUPERUSER_PASSWORD
+fi
+
+/opt/murmur/murmur.x86 -fg -v


### PR DESCRIPTION
```
docker run -d -e SUPERUSER_PASSWORD=foobar mattikus/murmur
```

Removes the need to check the logs for the password and makes it easier to automate setting up servers
