### PR TITLE
Bump to version 1.2.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM busybox:latest
 MAINTAINER Matt Kemp <matt@mattikus.com>
 
-ENV version=1.2.18
+ENV version=1.2.19
 
 # Download statically compiled murmur and install it to /opt/murmur
 ADD https://github.com/mumble-voip/mumble/releases/download/${version}/murmur-static_x86-${version}.tar.bz2 /opt/


### PR DESCRIPTION
Hi,

thanks for your work. 
I updated the Dockerfile with the latest Mumble version (1.2.19).