### PR TITLE
Remove ADD layer and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM busybox:latest
-MAINTAINER Matt Kemp <matt@mattikus.com>
+FROM busybox:latest AS builder
+LABEL MAINTAINER="Matt Kemp <matt@mattikus.com>"
 
 ENV version=1.3.2
 
@@ -10,6 +10,11 @@ RUN wget "https://github.com/mumble-voip/mumble/releases/download/${version}/mur
     bzcat murmurd.tar.bz2 | tar -x -f - && \
     rm murmurd.tar.bz2 && \
     mv murmur-static_x86-${version} /opt/murmur
+
+FROM busybox:latest
+
+# Grab murmurd from builder stage
+COPY --from=builder /opt/murmur /opt/murmur
 
 # Copy in our slightly tweaked INI which points to our volume
 COPY murmur.ini /etc/murmur.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ MAINTAINER Matt Kemp <matt@mattikus.com>
 ENV version=1.3.2
 
 # Download statically compiled murmur and install it to /opt/murmur
-ADD https://github.com/mumble-voip/mumble/releases/download/${version}/murmur-static_x86-${version}.tar.bz2 /opt/
-RUN bzcat /opt/murmur-static_x86-${version}.tar.bz2 | tar -x -C /opt -f - && \
-    rm /opt/murmur-static_x86-${version}.tar.bz2 && \
-    mv /opt/murmur-static_x86-${version} /opt/murmur
+WORKDIR /opt
+RUN wget "https://github.com/mumble-voip/mumble/releases/download/${version}/murmur-static_x86-${version}.tar.bz2" \
+        -O murmurd.tar.bz2 && \
+    bzcat murmurd.tar.bz2 | tar -x -f - && \
+    rm murmurd.tar.bz2 && \
+    mv murmur-static_x86-${version} /opt/murmur
 
 # Copy in our slightly tweaked INI which points to our volume
 COPY murmur.ini /etc/murmur.ini


### PR DESCRIPTION
The current Dockerfile leaves a lingering `/opt/murmur-static_x86-${version}.tar.bz2` file.
Instead of using **ADD**, use `wget` to download the tar.bz2 and remove it in the same layer.

```
$ dive mattikus/murmur
Total Image size: 49 MB
Potential wasted space: 12 MB
Image efficiency score: 74 %

Count   Total Space  Path
    2         12 MB  /opt/murmur-static_x86-1.3.2.tar.bz2
```

Alternatively, this could be done with a multi-stage build.